### PR TITLE
ヘッダーのナビゲーションを追加

### DIFF
--- a/airs/static/airs/css/style.css
+++ b/airs/static/airs/css/style.css
@@ -39,6 +39,10 @@ h6 {
   text-decoration: underline;
 }
 
+.mg-s {
+  margin: 4px;
+}
+
 .mgt-s {
   margin-top: 4px;
 }

--- a/airs/templates/airs/air_create.html
+++ b/airs/templates/airs/air_create.html
@@ -6,34 +6,39 @@
 {% block header %}
 {% endblock header %}
 
-{% block content %}
-<div class="rn-padding">
-    <form method="post">{% csrf_token %}
-        {% comment %} {{ form.as_p }} {% endcomment %} {% comment %} Formで指定したデータをセット {% endcomment %}
-        <fieldset class="uk-fieldset">
-            <label for="id_share_text" class="uk-legend">放送登録&amp;何卒</label>
-            <div class="uk-margin">
-                <input name="overview_before" id="id_share_text" maxlength="400" required="required" class="uk-input" type="text" placeholder="シェアラジオをコピペ" autofocus>
-            </div>
-            <input type="submit" value="送信" class="uk-button uk-button-primary uk-width-1-1 uk-margin-small-bottom">
-        </fieldset>
-    </form>
-</div>
+{% block nav %}
+<nav class="uk-navbar-container" uk-navbar>
+    <h1 class="uk-navbar-left uk-text-default uk-margin-remove rn-padding">放送登録&nbsp;&amp;&nbsp;何卒</h1>
+    <div class="uk-navbar-right">
+        <input type="submit" form="form" value="&nbsp;登録&nbsp;" class="uk-button uk-button-primary uk-button rn-padding-horizontal mg-s">
+    </div>
+</nav>
+<hr class="uk-margin-remove">
+{% endblock nav %}
 
-{% include 'base/separator.html' %}
+{% block content %}
+<form id="form" method="post">{% csrf_token %}
+    <fieldset class="uk-fieldset">
+        <div class="rn-padding">
+            <input name="overview_before" id="id_share_text" maxlength="400" required="required" class="uk-input" type="text" placeholder="シェアラジオをコピペ" autofocus>
+        </div>
+    </fieldset>
+</form>
+
+<hr class="uk-margin-remove">
 
 <div class="rn-padding uk-text-small" style="flex-wrap: wrap;">
-    <h4>シェアラジオの例</h4>
+    <h2 class="uk-text-default uk-margin-remove">シェアラジオの例</h2>
     <p style="word-break: break-all;">例1 基本：<br>
-番組名 | 放送局 | 2021/07/12/月 24:00-25:00 https://radiko.jp/share/?sid=TBS&t=20210713000000<br>
-<br>
-例2 SNS版：<br>
-番組名 │ 放送局 | https://radiko.jp/share/?sid=TBS&t=20210713000000 #radiko #タグ1 #タグ2 #タグ3<br>
-<br>
-例3 URLのみ：<br>
-https://radiko.jp/share/?sid=TBS&t=20210713000000</p>
+        番組名 | 放送局 | 2021/07/12/月 24:00-25:00 https://radiko.jp/share/?sid=TBS&t=20210713000000<br>
+        <br>
+        例2 SNS版：<br>
+        番組名 │ 放送局 | https://radiko.jp/share/?sid=TBS&t=20210713000000 #radiko #タグ1 #タグ2 #タグ3<br>
+        <br>
+        例3 URLのみ：<br>
+        https://radiko.jp/share/?sid=TBS&t=20210713000000</p>
 
-    <h4>補足</h4>
+    <h2 class="uk-text-default uk-margin-remove">補足</h2>
     <ul>
         <li>送信内容からラジコのURLを抜き出して放送情報を取得へ</li>
         <li>サイトのタイトルだけ見るのでTF期間が終わると取得不可</li>

--- a/airs/templates/airs/air_detail.html
+++ b/airs/templates/airs/air_detail.html
@@ -6,6 +6,53 @@
 {% block header %}
 {% endblock header %}
 
+{% block nav %}
+{% if user.is_authenticated %}
+<nav class="uk-navbar-container" uk-navbar>
+  <div class="uk-navbar-left"></div>
+  <div class="uk-navbar-right">
+    <ul class="uk-navbar-nav">
+      <li><a href="{% url 'airs:air_update' air.id %}">放送概要編集</a></li>
+      {% if my_nanitozo %}
+      <li><a href="{% url 'airs:nanitozo_update' my_nanitozo.id %}">何卒編集</a></li>
+      <li>
+        <a href="#">…</a>
+        <div uk-dropdown="pos: top-center">
+          <ul class="uk-nav uk-navbar-dropdown-nav">
+            <li>
+              <a href="#nanitozo-delete" uk-toggle>何卒取消</a>
+              <div id="nanitozo-delete" uk-modal>
+                <div class="uk-modal-dialog">
+                  <button class="uk-modal-close-default" type="button" uk-close></button>
+                  <div class="uk-modal-header">
+                    <h2 class="uk-modal-title">何卒を取り消す</h2>
+                  </div>
+                  <div class="uk-modal-body">
+                    <p>何卒を取り消す場合は「実行」をタップ！<br><br><span class="uk-text-danger">※投稿した各種感想文も削除されます</span><br><span class="uk-text-danger">※放送は削除されないしできません（必要があれば管理者に依頼を）</span></p>
+                  </div>
+                  <div class="uk-modal-footer uk-text-right">
+                    <button class="uk-button uk-button-default uk-modal-close" type="button">キャンセル</button>
+                    <a href="{% url 'airs:nanitozo_delete' air_id=air.id pk=my_nanitozo.id %}" class="uk-button uk-button-danger" type="button">実行</a>
+                  </div>
+                </div>
+              </div>
+            </li>
+          </ul>
+        </div>
+      </li>
+      {% else %}
+      <li><a href="{% url 'airs:nanitozo_create' air.id %}" class="uk-text-primary">何卒！</a></li>
+      {% endif %}
+    </ul>
+  </div>
+</nav>
+<hr class="uk-margin-remove">
+
+{% comment %} <a class="uk-button uk-button-danger uk-width-1-1 uk-margin-bottom" href="#nanitozo-delete" uk-toggle>何卒取消</a> {% endcomment %}
+
+{% endif %}
+{% endblock nav %}
+
 {% block content %}
 
 {% with adt=air.started_at|init_rn_datetime:air.ended_at %}
@@ -44,32 +91,6 @@
 {% include 'base/separator.html' %}
 
 <div class="rn-padding">
-  {% if user.is_authenticated %}
-  {% if my_nanitozo %}
-  <a href="{% url 'airs:nanitozo_update' my_nanitozo.id %}" class="uk-button uk-button-primary uk-width-1-1 uk-margin-bottom">何卒編集</a>
-
-  <a class="uk-button uk-button-danger uk-width-1-1 uk-margin-bottom" href="#nanitozo-delete" uk-toggle>何卒取消</a>
-  <div id="nanitozo-delete" uk-modal>
-    <div class="uk-modal-dialog">
-      <button class="uk-modal-close-default" type="button" uk-close></button>
-      <div class="uk-modal-header">
-        <h2 class="uk-modal-title">何卒を取り消す</h2>
-      </div>
-      <div class="uk-modal-body">
-        <p>何卒を取り消す場合は「実行」をタップ！<br><br><span class="uk-text-danger">※投稿した各種感想文も削除されます</span><br><span class="uk-text-danger">※放送は削除されないしできません（必要があれば管理者に依頼を）</span></p>
-      </div>
-      <div class="uk-modal-footer uk-text-right">
-        <button class="uk-button uk-button-default uk-modal-close" type="button">キャンセル</button>
-        <a href="{% url 'airs:nanitozo_delete' air_id=air.id pk=my_nanitozo.id %}" class="uk-button uk-button-danger" type="button">実行</a>
-      </div>
-    </div>
-  </div>
-
-  {% else %}
-  <a href="{% url 'airs:nanitozo_create' air.id %}" class="uk-button uk-button-primary uk-width-1-1 uk-margin-bottom">何卒！</a>
-  {% endif %}
-  {% endif %}
-
   {% comment %} 何卒 {% endcomment %}
   {% include 'base/sum_reaction.html' with nanitozo_list=nanitozo_list icon='icon: user' label='何卒' is_negative=False %}
   {% comment %} 満足 {% endcomment %}
@@ -107,10 +128,6 @@
   </div>
   {% else %}
   <p class="uk-text-small uk-margin-remove">データなし</p>
-  {% endif %}
-
-  {% if user.is_authenticated %}
-  <a href="{% url 'airs:air_update' air.id %}" class="uk-button uk-button-primary uk-width-1-1 uk-margin-large-top">事前告知と番組内容を編集</a>
   {% endif %}
 </div>
 

--- a/airs/templates/airs/air_update.html
+++ b/airs/templates/airs/air_update.html
@@ -6,28 +6,36 @@
 {% block header %}
 {% endblock header %}
 
+{% block nav %}
+<nav class="uk-navbar-container" uk-navbar>
+    <h1 class="uk-navbar-left uk-text-default uk-margin-remove rn-padding">放送概要編集</h1>
+    <div class="uk-navbar-right">
+        <input type="submit" form="form" value="&nbsp;更新&nbsp;" class="uk-button uk-button-primary uk-button rn-padding-horizontal mg-s">
+    </div>
+</nav>
+<hr class="uk-margin-remove">
+{% endblock nav %}
+
 {% block content %}
-<article class="rn-padding">
-    <h1 class="uk-text-lead uk-margin-remove-bottom">放送概要編集</h1>
-    <p class="uk-article-meta uk-margin-remove-top">※この項目は共同編集で同時に他のリスナーが編集してたら上書きしてしまうので極力手早くお願いします（そのうち編集中でもいい感じに気付けるように修正します）</p>
-</article>
+<form id="form" method="post">{% csrf_token %}
+    <article class="rn-padding">
+        <p class="uk-article-meta uk-margin-remove">共同編集で上書きしあう可能性があるので極力手早くお願いします（そのうちいい感じに解決できる方法考えます）</p>
+    </article>
 
-{% include 'base/separator.html' %}
+    <hr class="uk-margin-remove">
 
-<article class="rn-padding">
-    <form method="post">{% csrf_token %}
+    <article class="rn-padding">
         <p class="uk-margin-remove"><label for="id_overview_before">事前告知<small> ネタバレなし</small></label>
-        <textarea name="overview_before" rows="4" id="id_overview_before" class="uk-textarea mgt-s" placeholder="ゲスト：なかやまきんに君
+            <textarea name="overview_before" rows="4" id="id_overview_before" class="uk-textarea mgt-s" placeholder="ゲスト：なかやまきんに君
 ・筋肉ルーレットカジノ">{{ air.overview_before|default_if_none:'' }}</textarea></p>
         <p class="uk-article-meta uk-margin-remove-top uk-margin-bottom">※前回の放送や放送前にTwitterで告知があったゲストや企画</p>
 
         <p class="uk-margin-remove"><label for="id_overview_after">放送内容<small> ネタバレあり</small></label>
-        <textarea name="overview_after" rows="4" id="id_overview_after" class="uk-textarea mgt-s" placeholder="飛び入りゲスト：岡村隆史
+            <textarea name="overview_after" rows="4" id="id_overview_after" class="uk-textarea mgt-s" placeholder="飛び入りゲスト：岡村隆史
 ・ご飯炊き対決
 ・ネスミスはパン">{{ air.overview_after|default_if_none:'' }}</textarea></p>
         <p class="uk-article-meta uk-margin-remove-top uk-margin-bottom">※放送前に発表がなかったゲストや企画<br>　放送内の印象的なワード</p>
 
-        <input type="submit" value="更新" class="uk-button uk-button-primary uk-width-1-1 uk-margin-small-bottom">
-    </form>
-</article>
+    </article>
+</form>
 {% endblock content %}

--- a/airs/templates/airs/base.html
+++ b/airs/templates/airs/base.html
@@ -25,6 +25,8 @@
 <body>
   <div id="app"></div>
   <div class="wrapper">
+    {% block nav %}
+    {% endblock nav %}
     <div class="content">
       {% if messages %}
       {% for message in messages %}
@@ -49,10 +51,11 @@ uk-alert-danger
       {% endblock content %}
     </div>
 
+    {% comment %} 入力フォームじゃない場合に下ナビ表示 {% endcomment %}
+    {% if request.resolver_match.url_name != 'nanitozo_update' and request.resolver_match.url_name != 'air_create' and request.resolver_match.url_name != 'air_update' %}
+
     <footer>
       <hr class="uk-margin-remove">
-      {% comment %} ログイン画面以外で表示 {% endcomment %}
-      {% comment %} {% if request.resolver_match.url_name != 'login' %} {% endcomment %}
       <nav class="uk-navbar-container" uk-navbar>
         <div class="uk-navbar-left">
           <ul class="uk-navbar-nav">
@@ -93,16 +96,18 @@ uk-alert-danger
               </div>
             </li>
           </ul>
-          <a href="{% url 'airs:air_create' %}" class="uk-button uk-button-primary uk-button-large rn-padding-horizontal">＋放送登録</a>
+          <a href="{% url 'airs:air_create' %}" class="uk-button uk-button-primary rn-padding-horizontal">+放送登録</a>
           {% else %}
           <ul class="uk-navbar-nav">
             <li><a href="{% url 'login' %}">ログイン</a></li>
           </ul>
           {% endif %}
         </div>
-        {% comment %} {% endif %} {% endcomment %}
       </nav>
     </footer>
+
+    {% endif %}
+
   </div>
 
 

--- a/airs/templates/airs/nanitozo_update.html
+++ b/airs/templates/airs/nanitozo_update.html
@@ -6,20 +6,27 @@
 {% block header %}
 {% endblock header %}
 
+{% block nav %}
+<nav class="uk-navbar-container" uk-navbar>
+    <h1 class="uk-navbar-left uk-text-default uk-margin-remove rn-padding">何卒編集</h1>
+    <div class="uk-navbar-right">
+        <input type="submit" form="form" value="&nbsp;更新&nbsp;" class="uk-button uk-button-primary uk-button rn-padding-horizontal mg-s">
+    </div>
+</nav>
+<hr class="uk-margin-remove">
+{% endblock nav %}
+
 {% block content %}
-<article class="rn-padding">
-    <h1 class="uk-text-lead uk-margin-small-bottom">何卒編集</h1>
-    <h2 class="uk-text-default uk-margin-remove-top uk-margin-remove-bottom">
-        {{ nanitozo.air.name }}<br>
-    </h2>
-    <p class="uk-text-small uk-margin-remove-top uk-margin-small-bottom">{{ nanitozo.air.started_at|rn_ymdhm }} {{ nanitozo.air.broadcaster.name }}</p>
-</article>
+<form id="form" method="post">{% csrf_token %}
+    <article class="rn-padding">
+        <h2 class="uk-text-default uk-margin-remove-top uk-margin-remove-bottom">
+            {{ nanitozo.air.name }}<br>
+        </h2>
+        <p class="uk-text-small uk-margin-remove">{{ nanitozo.air.started_at|rn_ymdhm }} {{ nanitozo.air.broadcaster.name }}</p>
+    </article>
+    <hr class="uk-margin-remove">
 
-{% include 'base/separator.html' %}
-
-<article class="rn-padding">
-    <form method="post">{% csrf_token %}
-
+    <article class="rn-padding">
         <p>
             <input type="checkbox" name="good" id="id_good" class="uk-checkbox" {% if nanitozo.good %} checked{% endif %}>
             <label for="id_good">満足<small> 個人的に満足だったらON</small></label>
@@ -46,7 +53,6 @@
         </p>
 
         {% comment %} {{ form.as_p }} {% endcomment %}
-        <input type="submit" value="更新" class="uk-button uk-button-primary uk-width-1-1 uk-margin-small-bottom">
-    </form>
-</article>
+    </article>
+</form>
 {% endblock content %}


### PR DESCRIPTION
- 編集系の画面では下のグローバルナビを隠す
- 放送登録、放送編集、何卒編集のタイトルとsubmitをヘッダーに集約
- 放送詳細の各種遷移をヘッダーに集約してログイン時のみ表示