### PR TITLE
入力したコメントのURLをリンク化

### DIFF
--- a/airs/templates/airs/air_detail.html
+++ b/airs/templates/airs/air_detail.html
@@ -108,7 +108,7 @@
   <h3 class="uk-text-default uk-margin-small-bottom">事前告知<small> ネタバレなし（のはず）</small></h3>
   {% if air.overview_before %}
   <div class="uk-inline">
-    <p class="uk-text-small uk-margin-remove uk-text-break">{{ air.overview_before|linebreaksbr }}</p>
+    <p class="uk-text-small uk-margin-remove uk-text-break">{{ air.overview_before|urlizetrunc:16|linebreaksbr }}</p>
     <div onclick="this.remove()" class="uk-overlay-primary uk-background-secondary uk-position-cover">
       <div class="uk-position-center uk-text-small">Tap!</div>
     </div>
@@ -120,7 +120,7 @@
   <h3 class="uk-text-default uk-margin-small-bottom">番組内容<small> ネタバレあり</small></h3>
   {% if air.overview_after %}
   <div class="uk-inline">
-    <p class="uk-text-small uk-margin-remove uk-text-break">{{ air.overview_after|linebreaksbr }}</p>
+    <p class="uk-text-small uk-margin-remove uk-text-break">{{ air.overview_after|urlizetrunc:16|linebreaksbr }}</p>
     <div onclick="this.remove()" class="uk-overlay-primary uk-background-secondary uk-position-cover">
       <div class="uk-position-center uk-text-small">Tap!</div>
     </div>

--- a/airs/templates/list/item_reaction.html
+++ b/airs/templates/list/item_reaction.html
@@ -20,11 +20,11 @@
                     <p class="uk-text-small uk-margin-remove uk-text-break">
                         {% comment %} 文字列で判定してるけどよくない {% endcomment %}
                         {% if title == 'ネガ' %}
-                        {{ nanitozo.comment_negative|linebreaksbr }}
+                        {{ nanitozo.comment_negative|urlizetrunc:16|linebreaksbr }}
                         {% elif title == '推し' %}
-                        {{ nanitozo.comment_recommend|linebreaksbr }}
+                        {{ nanitozo.comment_recommend|urlizetrunc:16|linebreaksbr }}
                         {% else %}
-                        {{ nanitozo.comment|linebreaksbr }}
+                        {{ nanitozo.comment|urlizetrunc:16|linebreaksbr }}
                         {% endif %}
                     </p>
                     {% if title == 'ネガ' %}


### PR DESCRIPTION
- テンプレートフィルタの`urlize`を使用
  - https://stackoverflow.com/questions/51243907/make-links-clickable-in-my-django-textfield
- 更に16文字以上あったら省略
  - `urlizetrunc:16`