### PR TITLE
langをjaにする

### DIFF
--- a/airs/templates/airs/base.html
+++ b/airs/templates/airs/base.html
@@ -1,7 +1,7 @@
 {% load static %}
 {% load rn_const %}
 <!DOCTYPE html>
-<html>
+<html lang="ja">
 
 <head>
   <meta charset="utf-8">


### PR DESCRIPTION
- Chromeがユーザー詳細画面に平仮名がないせいか中国語だと判断しだしたので