### PR TITLE
日時ラベルのズレを修正

### DIFF
--- a/airs/templatetags/rn_datetime.py
+++ b/airs/templatetags/rn_datetime.py
@@ -18,6 +18,8 @@ def air_date_label_text(air_started_at):
         return '明日'
     elif days == 0:  # 例 22023/02/15 5:00〜28:59（= 2023/02/16 4:59）
         return '今日'
+    elif days == -1:  # 例 22023/02/14 5:00〜28:59（= 2023/02/15 4:59）
+        return '昨日'
     elif days >= -6:  # 例 2023/02/09〜02/14 → 例 2023/02/09 5:00〜
         return '今週'
     elif days == -7:  # 例 2023/02/08 → 例 2023/02/08 5:00〜
@@ -39,6 +41,8 @@ def air_date_label_class(air_started_at):
         return 'uk-label-danger'  # 明日
     elif days == 0:  # 例 22023/02/15 5:00〜28:59（= 2023/02/16 4:59）
         return 'uk-label-danger'  # 今日
+    elif days == -1:  # 例 22023/02/14 5:00〜28:59（= 2023/02/15 4:59）
+        return 'uk-label-success'  # 昨日
     elif days >= -6:  # 例 2023/02/09〜02/14 → 例 2023/02/09 5:00〜
         return 'uk-label-success'  # 今週
     elif days == -7:  # 例 2023/02/08 → 例 2023/02/08 5:00〜

--- a/airs/tests/templatetags/rn_datetime_tests.py
+++ b/airs/tests/templatetags/rn_datetime_tests.py
@@ -8,6 +8,8 @@ from ...templatetags.rn_datetime import *
 
 class AirDateLabelTests(TestCase):
 
+    # 以下、freeze_time → not深夜
+
     @freezegun.freeze_time('2023-02-15 5:30:00')
     def test_2日後の日中の放送(self):
         air_started_at = timezone.make_aware(timezone.datetime(2023, 2, 17, 12, 0))
@@ -60,13 +62,29 @@ class AirDateLabelTests(TestCase):
     def test_昨日の日中の放送(self):
         air_started_at = timezone.make_aware(timezone.datetime(2023, 2, 14, 12, 0))
         response = air_date_label_text(air_started_at)
-        self.assertEqual(response, '今週')
+        self.assertEqual(response, '昨日')
         response = air_date_label_class(air_started_at)
         self.assertEqual(response, 'uk-label-success')
 
     @freezegun.freeze_time('2023-02-15 5:30:00')
     def test_昨日の深夜の放送(self):
         air_started_at = timezone.make_aware(timezone.datetime(2023, 2, 15, 1, 0))
+        response = air_date_label_text(air_started_at)
+        self.assertEqual(response, '昨日')
+        response = air_date_label_class(air_started_at)
+        self.assertEqual(response, 'uk-label-success')
+
+    @freezegun.freeze_time('2023-02-15 5:30:00')
+    def test_昨日の日中の放送(self):
+        air_started_at = timezone.make_aware(timezone.datetime(2023, 2, 13, 12, 0))
+        response = air_date_label_text(air_started_at)
+        self.assertEqual(response, '今週')
+        response = air_date_label_class(air_started_at)
+        self.assertEqual(response, 'uk-label-success')
+
+    @freezegun.freeze_time('2023-02-15 5:30:00')
+    def test_昨日の深夜の放送(self):
+        air_started_at = timezone.make_aware(timezone.datetime(2023, 2, 14, 1, 0))
         response = air_date_label_text(air_started_at)
         self.assertEqual(response, '今週')
         response = air_date_label_class(air_started_at)
@@ -152,7 +170,9 @@ class AirDateLabelTests(TestCase):
         response = air_date_label_class(air_started_at)
         self.assertEqual(response, 'uk-hidden')
 
-    #
+    # ここまで、freeze_time → not深夜
+
+    # 以下、freeze_time → is深夜
 
     @freezegun.freeze_time('2023-02-16 4:59:00')
     def test_深夜から2日後の日中の放送(self):
@@ -206,13 +226,29 @@ class AirDateLabelTests(TestCase):
     def test_深夜から昨日の日中の放送(self):
         air_started_at = timezone.make_aware(timezone.datetime(2023, 2, 14, 12, 0))
         response = air_date_label_text(air_started_at)
-        self.assertEqual(response, '今週')
+        self.assertEqual(response, '昨日')
         response = air_date_label_class(air_started_at)
         self.assertEqual(response, 'uk-label-success')
 
     @freezegun.freeze_time('2023-02-16 4:59:00')
     def test_深夜から昨日の深夜の放送(self):
         air_started_at = timezone.make_aware(timezone.datetime(2023, 2, 15, 1, 0))
+        response = air_date_label_text(air_started_at)
+        self.assertEqual(response, '昨日')
+        response = air_date_label_class(air_started_at)
+        self.assertEqual(response, 'uk-label-success')
+
+    @freezegun.freeze_time('2023-02-16 4:59:00')
+    def test_深夜から昨日の日中の放送(self):
+        air_started_at = timezone.make_aware(timezone.datetime(2023, 2, 13, 12, 0))
+        response = air_date_label_text(air_started_at)
+        self.assertEqual(response, '今週')
+        response = air_date_label_class(air_started_at)
+        self.assertEqual(response, 'uk-label-success')
+
+    @freezegun.freeze_time('2023-02-16 4:59:00')
+    def test_深夜から昨日の深夜の放送(self):
+        air_started_at = timezone.make_aware(timezone.datetime(2023, 2, 14, 1, 0))
         response = air_date_label_text(air_started_at)
         self.assertEqual(response, '今週')
         response = air_date_label_class(air_started_at)
@@ -297,3 +333,5 @@ class AirDateLabelTests(TestCase):
         self.assertEqual(response, '')
         response = air_date_label_class(air_started_at)
         self.assertEqual(response, 'uk-hidden')
+
+    # ここまで、freeze_time → is深夜

--- a/common/util/datetime_extensions.py
+++ b/common/util/datetime_extensions.py
@@ -78,6 +78,7 @@ def air_started_diff_days(air_started):
         now = timedelta_days(now, -1)
     today = new_datetime(now.year, now.month, now.day, 5, 0)
 
+    air_started = air_started.astimezone(pytztimezone('Asia/Tokyo'))  # タイムゾーンを日本時間にする
     if __is_midnight(air_started):
         air_started = timedelta_days(air_started, -1)
     aired = new_datetime(air_started.year, air_started.month, air_started.day, 5, 0)


### PR DESCRIPTION
- 判断元の放送時間を東京時間に変えていなかったので処理を追加
- ついでに「昨日」を追加