### PR TITLE
feat: ユーザー詳細画面の年度制限を撤廃

### DIFF
--- a/common/util/summary_extensions.py
+++ b/common/util/summary_extensions.py
@@ -5,10 +5,6 @@ import datetime
 from django.utils.timezone import make_aware
 
 
-MAX_YEAR = 2023
-MIN_YEAR = 2019
-
-
 def this_month():
     now = datetime.datetime.now()
     this_month = make_aware(datetime.datetime(now.year, now.month, 1, 0, 0))
@@ -16,10 +12,27 @@ def this_month():
 
 
 def yearly_count_list(monthly_count_list):
+    # データが存在しない場合は空のリストを返す
+    if not monthly_count_list:
+        return []
+
+    # monthly_count_list から最小年と最大年を動的に計算
+    monthly_list = list(monthly_count_list)
+    if not monthly_list:
+        return []
+
+    # 4月始まりの年度として考慮して最小年・最大年を計算
+    min_date = min(monthly_list, key=lambda x: x['monthly_date'])['monthly_date']
+    max_date = max(monthly_list, key=lambda x: x['monthly_date'])['monthly_date']
+
+    # 4月始まりの年度として考慮（3月以前は前年度扱い）
+    min_year = min_date.year if min_date.month >= 4 else min_date.year - 1
+    max_year = max_date.year if max_date.month >= 4 else max_date.year - 1
+
     yearly_count_list = []
-    target_year = MAX_YEAR  # こっちが最大値（例：2023年まで）
-    while target_year >= MIN_YEAR:  # こちらが最小値（例：2021年から）
-        yearly = yearly_count(monthly_count_list, target_year)
+    target_year = max_year  # こっちが最大値
+    while target_year >= min_year:  # こちらが最小値
+        yearly = yearly_count(monthly_list, target_year)
         yearly_count_list.append(yearly)
         target_year -= 1
     return yearly_count_list


### PR DESCRIPTION
ユーザー詳細画面で2019年〜2023年に固定されていた表示年度を、
データが存在する全期間に拡張。

## 変更内容
- MAX_YEAR/MIN_YEARの固定値を削除
- yearly_count_list()でデータから動的に年度範囲を計算
- 4月始まりの年度として適切に処理

## 効果
- 2024年以降、2018年以前のデータも自動表示
- 将来的な年度追加が不要

🤖 Generated with [Claude Code](https://claude.com/claude-code)